### PR TITLE
Fixing Pattern Lab CLI path for the {{ inline }} function

### DIFF
--- a/build/tasks/patternlab.js
+++ b/build/tasks/patternlab.js
@@ -19,7 +19,7 @@ module.exports = function (gulp, config, $) {
             message: "Error: <%= error.message %>"
           })
         }))
-        .pipe($.exec('php  -d memory_limit=1024M pattern-lab/core/console --generate --patternsonly'))
+        .pipe($.exec('cd pattern-lab && php core/console -gpn'))
         .pipe($.exec.reporter(reportOptions));
         
   });


### PR DESCRIPTION
Updating PL build CLI command to speed up compilation time + use updated path syntax